### PR TITLE
make ExpoMessageSound constructors public

### DIFF
--- a/src/main/java/io/github/jav/exposerversdk/ExpoMessageSound.java
+++ b/src/main/java/io/github/jav/exposerversdk/ExpoMessageSound.java
@@ -15,16 +15,16 @@ public class ExpoMessageSound implements JsonSerializable {
     private String name = null;
     private long volume = -1;
 
-    ExpoMessageSound() {
+    public ExpoMessageSound() {
     }
 
-    ExpoMessageSound(String _name) {
+    public ExpoMessageSound(String _name) {
         if (_name != null && !_name.equals("default"))
             throw new IllegalArgumentException();
         name = _name.toLowerCase();
     }
 
-    ExpoMessageSound(Boolean _critical, String _name, long _volume) {
+    public ExpoMessageSound(Boolean _critical, String _name, long _volume) {
         critical = _critical;
         name = _name;
         volume = _volume;


### PR DESCRIPTION
Make it possible to declare sound properties by setting constructor visibility to public.