### PR TITLE
Support for nested pojos, invalid tokens, exception swallowing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.github.jav</groupId>
     <artifactId>expo-server-sdk</artifactId>
-    <version>0.7.0-PATCH</version>
+    <version>0.7.0-PATCH2</version>
     <name>expo-server-sdk</name>
     <description>
         Java implementation of expo-server-sdk implementation.

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.github.jav</groupId>
     <artifactId>expo-server-sdk</artifactId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>0.7.0-PATCH</version>
     <name>expo-server-sdk</name>
     <description>
         Java implementation of expo-server-sdk implementation.

--- a/src/main/java/io/github/jav/exposerversdk/DefaultExpoPushMessage.java
+++ b/src/main/java/io/github/jav/exposerversdk/DefaultExpoPushMessage.java
@@ -1,0 +1,34 @@
+package io.github.jav.exposerversdk;
+
+import java.util.List;
+import java.util.Map;
+
+public class DefaultExpoPushMessage extends ExpoPushMessage<Map<String,String>> {
+
+    // super ugly https://stackoverflow.com/questions/22152982/passing-parameterized-class-instance-to-the-constructor
+    private static Class<Map<String,String>> _mapClazz = (Class<Map<String,String>>)(Class<?>)Map.class;
+    
+    @SuppressWarnings("unchecked")
+    public DefaultExpoPushMessage() {
+        super(_mapClazz);
+    }
+    
+
+    public DefaultExpoPushMessage(List<String> _to, DefaultExpoPushMessage _message) {
+        super (_to, _message);
+    }
+
+    public DefaultExpoPushMessage(List<String> _to) {
+        super (_to, _mapClazz);
+    }
+
+    public DefaultExpoPushMessage(String _to) {    
+        super (_to, _mapClazz);
+    }
+    
+    @Override
+    public DefaultExpoPushMessage toChunk(List<String> partialTo) {
+        return new DefaultExpoPushMessage(partialTo, this);
+    }
+
+}

--- a/src/main/java/io/github/jav/exposerversdk/DefaultPushClient.java
+++ b/src/main/java/io/github/jav/exposerversdk/DefaultPushClient.java
@@ -1,0 +1,7 @@
+package io.github.jav.exposerversdk;
+
+public class DefaultPushClient extends PushClient<DefaultExpoPushMessage> {
+    public DefaultPushClient() {
+        super();
+    }
+}

--- a/src/main/java/io/github/jav/exposerversdk/ExpoPushMessage.java
+++ b/src/main/java/io/github/jav/exposerversdk/ExpoPushMessage.java
@@ -12,13 +12,16 @@ import java.io.IOException;
 import java.util.*;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonIgnoreProperties({"_debug"})
-public class ExpoPushMessage implements JsonSerializable {
+@JsonIgnoreProperties({"_debug", "_clazz"})
+public class ExpoPushMessage<T> implements JsonSerializable {
 
+    //required for equality. If this is not a hard requirement, can remove
+    protected final Class<T> _clazz;
+    
     @JsonProperty("to")
     public List<String> to = null;
     @JsonProperty("data")
-    public Map<String, String> data = null;
+    public T data = null;
     @JsonProperty("title")
     public String title = null;
     @JsonProperty("subtitle")
@@ -38,11 +41,13 @@ public class ExpoPushMessage implements JsonSerializable {
     @JsonProperty("channelId")
     public String channelId = null;
 
-    public ExpoPushMessage() {
+    public ExpoPushMessage(Class<T> clazz) {
         to = new ArrayList<>();
+        this._clazz = clazz;
     }
 
-    public ExpoPushMessage(List<String> _to, ExpoPushMessage _message) {
+    public ExpoPushMessage(List<String> _to, ExpoPushMessage<T> _message) {
+        _clazz = _message._clazz;
         to = _to;
         data = _message.data;
         title = _message.title;
@@ -56,13 +61,16 @@ public class ExpoPushMessage implements JsonSerializable {
         channelId = _message.channelId;
     }
 
-    public ExpoPushMessage(List<String> _to) {
+    public ExpoPushMessage(List<String> _to, Class<T> clazz) {
+        _clazz = clazz;
         to = _to;
     }
 
-    public ExpoPushMessage(String _to) {
-        to = Arrays.asList(_to);
+    public ExpoPushMessage(String _to, Class<T> clazz) {
+        this (Arrays.asList(_to), clazz);
     }
+    
+
 
     @JsonProperty("to")
     public List<String> getTo() {
@@ -75,12 +83,12 @@ public class ExpoPushMessage implements JsonSerializable {
     }
 
     @JsonProperty("data")
-    public Map<String, String> getData() {
+    public T getData() {
         return data;
     }
 
     @JsonProperty("data")
-    public void setData(Map<String, String> data) {
+    public void setData(T data) {
         this.data = data;
     }
 
@@ -227,8 +235,10 @@ public class ExpoPushMessage implements JsonSerializable {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof ExpoPushMessage)) return false;
-        ExpoPushMessage that = (ExpoPushMessage) o;
-        return getTtl() == that.getTtl() &&
+        @SuppressWarnings("unchecked")
+        ExpoPushMessage<T> that = (ExpoPushMessage<T>) o;
+        return _clazz.equals(that._clazz) &&
+                getTtl() == that.getTtl() &&
                 getExpiration() == that.getExpiration() &&
                 getBadge() == that.getBadge() &&
                 Objects.equals(getTo(), that.getTo()) &&
@@ -244,6 +254,10 @@ public class ExpoPushMessage implements JsonSerializable {
     @Override
     public int hashCode() {
         return Objects.hash(getTo(), getData(), getTitle(), getSubtitle(), getBody(), getSound(), getTtl(), getExpiration(), getPriority(), getBadge(), getChannelId());
+    }
+
+    public ExpoPushMessage<T> toChunk(List<String> partialTo) {
+        return new ExpoPushMessage<T>(partialTo, this);
     }
 };
 

--- a/src/main/java/io/github/jav/exposerversdk/ExpoPushReceiept.java
+++ b/src/main/java/io/github/jav/exposerversdk/ExpoPushReceiept.java
@@ -27,6 +27,23 @@ public class ExpoPushReceiept implements JsonSerializable {
 
     @JsonIgnore
     private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+    
+    @JsonIgnore
+    private Exception cause;
+    
+    public ExpoPushReceiept() {
+        
+    }
+    public ExpoPushReceiept(String id, Exception cause) {
+        this.id = id;
+        this.cause = cause;
+        this.status = Status.EXCEPTION;
+        this.message = cause.getClass().getName();
+        this.details = new Details();
+        details.error = cause.getMessage();
+        
+        
+    }
 
     @JsonProperty("status")
     public Status getStatus() {
@@ -66,6 +83,11 @@ public class ExpoPushReceiept implements JsonSerializable {
     @JsonAnySetter
     public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
+    }
+    
+    public Exception getCause() {
+        return cause;
+        
     }
 
 

--- a/src/main/java/io/github/jav/exposerversdk/ExpoPushResponse.java
+++ b/src/main/java/io/github/jav/exposerversdk/ExpoPushResponse.java
@@ -1,0 +1,46 @@
+package io.github.jav.exposerversdk;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown=true)
+public class ExpoPushResponse {
+    List<ExpoPushTicket> data = null;
+    List<String> invalidTokens = null;
+    Status status;
+    Exception cause;
+    public List<ExpoPushTicket> getData() {
+        return data;
+    }
+    public void setData(List<ExpoPushTicket> data) {
+        this.data = data;
+    }
+    public List<String> getInvalidTokens() {
+        return invalidTokens;
+    }
+    public void setInvalidTokens(List<String> invalidTokens) {
+        this.invalidTokens = invalidTokens;
+    }
+    public Status getStatus() {
+        return status;
+    }
+    public void setStatus(Status status) {
+        this.status = status;
+    }
+    public Exception getCause() {
+        return cause;
+    }
+    public void setCause(Exception cause) {
+        this.cause = cause;
+    }
+    @Override
+    public String toString() {
+        return "ExpoPushResponse [data=" + data + ", invalidTokens=" + invalidTokens + ", status=" + status + "]";
+    }
+    
+    
+    
+}

--- a/src/main/java/io/github/jav/exposerversdk/ExpoPushTicket.java
+++ b/src/main/java/io/github/jav/exposerversdk/ExpoPushTicket.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializable;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
-import org.apache.commons.lang3.builder.EqualsBuilder;
 
 import java.io.IOException;
 import java.util.HashMap;

--- a/src/main/java/io/github/jav/exposerversdk/ExpoPushTicket.java
+++ b/src/main/java/io/github/jav/exposerversdk/ExpoPushTicket.java
@@ -23,6 +23,19 @@ public class ExpoPushTicket implements JsonSerializable {
     private String message = null;
     @JsonProperty("details")
     private ExpoPushTicket.Details details = null;
+    @JsonIgnore
+    private Exception cause = null;
+    
+    public ExpoPushTicket() {
+        
+    }
+    public ExpoPushTicket(Exception cause) {
+        this.cause = cause;
+        this.status = Status.EXCEPTION;
+        this.message = cause.getClass().getName();
+        this.details = new ExpoPushTicket.Details();
+        this.details.error = cause.getMessage();
+    }
 
     @JsonIgnore
     private Map<String, Object> additionalProperties = new HashMap<String, Object>();
@@ -67,6 +80,10 @@ public class ExpoPushTicket implements JsonSerializable {
         this.additionalProperties.put(name, value);
     }
 
+    public Exception getCause() {
+        return cause;
+    }
+    
     @Override
     public void serialize(JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
         jsonGenerator.writeStartObject();

--- a/src/main/java/io/github/jav/exposerversdk/ExpoPushTicket.java
+++ b/src/main/java/io/github/jav/exposerversdk/ExpoPushTicket.java
@@ -17,6 +17,8 @@ public class ExpoPushTicket implements JsonSerializable {
 
     @JsonProperty("id")
     public String id = null;
+    @JsonProperty("to")
+    public String to = null;
     @JsonProperty("status")
     private Status status = null;
     @JsonProperty("message")
@@ -69,6 +71,14 @@ public class ExpoPushTicket implements JsonSerializable {
     public void setDetails(ExpoPushTicket.Details details) {
         this.details = details;
     }
+    @JsonProperty("to")
+    public String getTo() {
+        return to;
+    }
+    @JsonProperty("to")
+    public void setTo(String to) {
+        this.to = to;
+    }
 
     @JsonAnyGetter
     public Map<String, Object> getAdditionalProperties() {
@@ -100,7 +110,13 @@ public class ExpoPushTicket implements JsonSerializable {
         jsonGenerator.writeEndObject();
         return;
     }
+    
 
+    @Override
+    public String toString() {
+        return "ExpoPushTicket [id=" + id + ", status=" + status + ", message=" + message + ", details=" + details + ", additionalProperties="
+                + additionalProperties + "]";
+    }
     @Override
     public void serializeWithType(JsonGenerator jsonGenerator, SerializerProvider serializerProvider, TypeSerializer typeSerializer) throws IOException {
         throw new UnsupportedOperationException("serializeWithType() not implemented.");
@@ -178,5 +194,17 @@ public class ExpoPushTicket implements JsonSerializable {
         public int hashCode() {
             return Objects.hash(getError(), getSentAt(), getAdditionalProperties());
         }
+
+        public void setAdditionalProperties(Map<String, Object> additionalProperties) {
+            this.additionalProperties = additionalProperties;
+        }
+
+        @Override
+        public String toString() {
+            return "Details [error=" + error + ", sentAt=" + sentAt + ", additionalProperties=" + additionalProperties + "]";
+        }
+        
+        
+        
     }
 }

--- a/src/main/java/io/github/jav/exposerversdk/PushClient.java
+++ b/src/main/java/io/github/jav/exposerversdk/PushClient.java
@@ -62,7 +62,7 @@ public class PushClient<Z extends ExpoPushMessage<?>> {
                             List<String> invalidTokens = new ArrayList<>();
                             response.setInvalidTokens(invalidTokens);
                             for (int i=0; i< data.size(); i++) {
-                                while (++currentRecepientIndex >= currentRecepientSize) {
+                                if (++currentRecepientIndex >= currentRecepientSize) {
                                     currentMessageIndex++;
                                     currentMessage = messages.get(currentMessageIndex);
                                     currentRecepientIndex = 0;

--- a/src/main/java/io/github/jav/exposerversdk/PushClient.java
+++ b/src/main/java/io/github/jav/exposerversdk/PushClient.java
@@ -60,8 +60,9 @@ public class PushClient<Z extends ExpoPushMessage<?>> {
                             Status overallStatus = Status.OK;
                             // we need to find the invalid recepients
                             List<String> invalidTokens = new ArrayList<>();
+                            response.setInvalidTokens(invalidTokens);
                             for (int i=0; i< data.size(); i++) {
-                                if (++currentRecepientIndex > currentRecepientSize) {
+                                while (++currentRecepientIndex >= currentRecepientSize) {
                                     currentMessageIndex++;
                                     currentMessage = messages.get(currentMessageIndex);
                                     currentRecepientIndex = 0;
@@ -77,11 +78,10 @@ public class PushClient<Z extends ExpoPushMessage<?>> {
                                         invalidTokens.add(ticket.getTo());   
                                     }
                                 }
-                                response.setInvalidTokens(invalidTokens);
                             }
                             
                             return response;
-                        } catch (IOException e) {
+                        } catch (Exception e) {
                             ExpoPushResponse response = new ExpoPushResponse();
                             response.setStatus(Status.ERROR);
                             response.setCause(e);

--- a/src/main/java/io/github/jav/exposerversdk/PushClient.java
+++ b/src/main/java/io/github/jav/exposerversdk/PushClient.java
@@ -13,6 +13,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 
 public class PushClient<Z extends ExpoPushMessage<?>> {
     static public final long PUSH_NOTIFICATION_CHUNK_LIMIT = 100;
@@ -49,17 +50,13 @@ public class PushClient<Z extends ExpoPushMessage<?>> {
                                 retList.add(mapper.convertValue(node, ExpoPushTicket.class));
                             }
                             return retList;
-                        } catch (JsonProcessingException e) {
-                            e.printStackTrace();
                         } catch (IOException e) {
-                            e.printStackTrace();
+                            return messages.stream().map(m -> new ExpoPushTicket(e)).collect(Collectors.toList());
                         }
-                        return null;
                     });
         } catch (MalformedURLException e) {
-            e.printStackTrace();
+            throw new IllegalStateException("Incorrect baseApiUrl" + baseApiUrl, e);
         }
-        return null;
     }
 
     public CompletableFuture<List<ExpoPushReceiept>> getPushNotificationReceiptsAsync(List<String> _ids) {
@@ -81,19 +78,15 @@ public class PushClient<Z extends ExpoPushMessage<?>> {
                                 retList.add(epr);
                             }
                             return retList;
-                        } catch (JsonProcessingException e) {
-                            e.printStackTrace();
                         } catch (IOException e) {
-                            e.printStackTrace();
+                            return _ids.stream().map(id -> new ExpoPushReceiept(id, e)).collect(Collectors.toList());
                         }
-                        return null;
                     });
         } catch (URISyntaxException e) {
-            e.printStackTrace();
+            throw new IllegalStateException("Incorrect baseApiUrl" + baseApiUrl, e);
         } catch (MalformedURLException e) {
-            e.printStackTrace();
+            throw new IllegalStateException("Incorrect baseApiUrl" + baseApiUrl, e);
         }
-        return null;
     }
 
     protected <T> CompletableFuture<String> _postNotificationAsync(URL url, List<T> messages) {
@@ -104,7 +97,7 @@ public class PushClient<Z extends ExpoPushMessage<?>> {
             json = objectMapper.
                     writeValueAsString(messages);
         } catch (JsonProcessingException e) {
-            e.printStackTrace();
+            throw new IllegalStateException("Could not convert to json", e);
         }
         return pushServerResolver.postAsync(url, json);
     }
@@ -128,7 +121,7 @@ public class PushClient<Z extends ExpoPushMessage<?>> {
             json = objectMapper.
                     writeValueAsString(jsonReceiptHelper);
         } catch (JsonProcessingException e) {
-            e.printStackTrace();
+            throw new IllegalStateException("Could not convert to json", e);
         }
         return pushServerResolver.postAsync(url, json);
     }

--- a/src/main/java/io/github/jav/exposerversdk/Status.java
+++ b/src/main/java/io/github/jav/exposerversdk/Status.java
@@ -6,7 +6,9 @@ public enum Status {
         @JsonProperty("ok")
         OK("ok"),
         @JsonProperty("error")
-        ERROR("error");
+        ERROR("error"),
+        @JsonProperty("exception")
+        EXCEPTION("exception");
 
         private String status;
         private Status(String status) {

--- a/src/test/java/io/github/jav/exposerversdk/ExpoPushMessageTest.java
+++ b/src/test/java/io/github/jav/exposerversdk/ExpoPushMessageTest.java
@@ -10,6 +10,7 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -24,8 +25,8 @@ class ExpoPushMessageTest {
         ExpoMessageSound soundA = new ExpoMessageSound();
         ExpoMessageSound soundB = new ExpoMessageSound();
 
-        ExpoPushMessage a = new ExpoPushMessage();
-        ExpoPushMessage b = new ExpoPushMessage();
+        DefaultExpoPushMessage a = new DefaultExpoPushMessage();
+        DefaultExpoPushMessage b = new DefaultExpoPushMessage();
         assertEquals(a, b);
 
         // check equals self, as in issue https://github.com/jav/expo-server-sdk-java/issues/6
@@ -55,7 +56,7 @@ class ExpoPushMessageTest {
 
     @Test
     void priorityMayOnlyBeDefaultNormalOrHigh() {
-        ExpoPushMessage eps = new ExpoPushMessage();
+        DefaultExpoPushMessage eps = new DefaultExpoPushMessage();
         eps.setPriority("deFAUlt");
         eps.setPriority("noRMal");
         eps.setPriority("hIGh");
@@ -78,7 +79,7 @@ class ExpoPushMessageTest {
         JsonGenerator generator = null;
         String epmJson = null;
         String jsonControl = null;
-        ExpoPushMessage epm = null;
+        ExpoPushMessage<Map<String,String>> epm = null;
 
         // Empty object
         writer = new StringWriter();
@@ -89,7 +90,7 @@ class ExpoPushMessageTest {
         generator.writeEndObject();
         generator.close();
         jsonControl = writer.toString();
-        epm = new ExpoPushMessage();
+        epm = new DefaultExpoPushMessage();
         epmJson = mapper.writeValueAsString(epm);
         assertEquals(mapper.readTree(jsonControl), mapper.readTree(epmJson));
 
@@ -109,7 +110,7 @@ class ExpoPushMessageTest {
         generator.writeEndObject();
         generator.close();
         jsonControl = writer.toString();
-        epm = new ExpoPushMessage(Arrays.asList("Recipient 1", "Recipient 2"));
+        epm = new DefaultExpoPushMessage(Arrays.asList("Recipient 1", "Recipient 2"));
         epm.title = "My title";
         ExpoMessageSound ems = new ExpoMessageSound("default");
         ems.setVolume(60);

--- a/src/test/java/io/github/jav/exposerversdk/NestedPojo.java
+++ b/src/test/java/io/github/jav/exposerversdk/NestedPojo.java
@@ -1,0 +1,68 @@
+package io.github.jav.exposerversdk;
+
+import java.util.List;
+
+public class NestedPojo {
+    int id;
+    InnerPojo i;
+    public NestedPojo() {
+        
+    }
+    public NestedPojo(int id, int a, String b, List<String> c) {
+        this.id = id;
+        this.i = new InnerPojo(a,b,c);
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public InnerPojo getI() {
+        return i;
+    }
+
+    public void setI(InnerPojo i) {
+        this.i = i;
+    }
+    
+
+
+    public static class InnerPojo {
+        private int a;
+        private String b;
+        private List<String> c;
+        public InnerPojo() {
+            
+        }
+        public InnerPojo(int a, String b, List<String> c) {
+            this.a = a;
+            this.b = b;
+            this.c = c;
+            
+        }
+        
+        public int getA() {
+            return a;
+        }
+        public void setA(int a) {
+            this.a = a;
+        }
+        public String getB() {
+            return b;
+        }
+        public void setB(String b) {
+            this.b = b;
+        }
+        public List<String> getC() {
+            return c;
+        }
+        public void setC(List<String> c) {
+            this.c = c;
+        }
+        
+    }
+}

--- a/src/test/java/io/github/jav/exposerversdk/PushClientTest.java
+++ b/src/test/java/io/github/jav/exposerversdk/PushClientTest.java
@@ -16,6 +16,7 @@ import java.util.concurrent.ExecutionException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
@@ -23,7 +24,7 @@ class PushClientTest {
 
     @Test
     public void apiBaseUrlIsOverridable() throws MalformedURLException {
-        PushClient client = new PushClient();
+        DefaultPushClient client = new DefaultPushClient();
         URL apiUrl = client.getBaseApiUrl();
         assertEquals(apiUrl, client.getBaseApiUrl());
         URL mockBaseApiUrl = new URL("http://example.com/");
@@ -33,21 +34,39 @@ class PushClientTest {
 
     @Test
     public void chunkListsOfPushNotificationMessages() {
-        PushClient client = new PushClient();
-        List<ExpoPushMessage> messages = new ArrayList<>(Collections.nCopies(999, new ExpoPushMessage("?")));
-        List<List<ExpoPushMessage>> chunks = client.chunkPushNotifications(messages);
+        DefaultPushClient client = new DefaultPushClient();
+        List<DefaultExpoPushMessage> messages = new ArrayList<>(Collections.nCopies(999, new DefaultExpoPushMessage("?")));
+        List<List<DefaultExpoPushMessage>> chunks = client.chunkPushNotifications(messages);
         long totalMessageCount = 0;
-        for (List<ExpoPushMessage> chunk : chunks) {
+        for (List<DefaultExpoPushMessage> chunk : chunks) {
             totalMessageCount += chunk.size();
         }
         assertEquals(totalMessageCount, messages.size());
     }
+    
+    @Test
+    public void chunkListsOfPushNotificationMessages2() {
+        PushClient<ExpoPushMessage<NestedPojo>> client = new PushClient<>();
+        NestedPojo test = new NestedPojo(14, 1, "Hello", Arrays.asList("World","!"));
+        ExpoPushMessage<NestedPojo> message = new ExpoPushMessage<>("?", NestedPojo.class);
+        message.setData(test);
+        List<ExpoPushMessage<NestedPojo>> messages = new ArrayList<>(Collections.nCopies(999, message));
+        List<List<ExpoPushMessage<NestedPojo>>> chunks = client.chunkPushNotifications(messages);
+        long totalMessageCount = 0;
+        for (List<ExpoPushMessage<NestedPojo>> chunk : chunks) {
+            totalMessageCount += chunk.size();
+            for (ExpoPushMessage<NestedPojo> m: chunk) {
+                assertSame(test, m.getData());
+            }
+        }
+        assertEquals(totalMessageCount, messages.size());
+    }    
 
     @Test
     public void canChunkSmallListsOfPushNotificationMessages() {
-        PushClient client = new PushClient();
-        List<ExpoPushMessage> messages = new ArrayList<>(Collections.nCopies(10, new ExpoPushMessage("?")));
-        List<List<ExpoPushMessage>> chunks = client.chunkPushNotifications(messages);
+        DefaultPushClient client = new DefaultPushClient();
+        List<DefaultExpoPushMessage> messages = new ArrayList<>(Collections.nCopies(10, new DefaultExpoPushMessage("?")));
+        List<List<DefaultExpoPushMessage>> chunks = client.chunkPushNotifications(messages);
         assertEquals(1, chunks.size());
         assertEquals(10, chunks.get(0).size());
     }
@@ -55,10 +74,10 @@ class PushClientTest {
     @Test
     public void canChunkSinglePushNotificationMessageWithListsOfRecipients() {
         int messagesLength = 999;
-        PushClient client = new PushClient();
-        List<ExpoPushMessage> messages = new ArrayList<>();
-        messages.add(new ExpoPushMessage(Collections.nCopies(messagesLength, "?")));
-        List<List<ExpoPushMessage>> chunks = client.chunkPushNotifications(messages);
+        DefaultPushClient client = new DefaultPushClient();
+        List<DefaultExpoPushMessage> messages = new ArrayList<>();
+        messages.add(new DefaultExpoPushMessage(Collections.nCopies(messagesLength, "?")));
+        List<List<DefaultExpoPushMessage>> chunks = client.chunkPushNotifications(messages);
         chunks.stream().forEach(
                 (c) -> assertEquals(1, c.size())
         );
@@ -69,10 +88,10 @@ class PushClientTest {
     @Test
     public void canChunkSinglePushNotificatoinMessageWithSmallListsOfRecipients() {
         int messagesLength = 10;
-        PushClient client = new PushClient();
-        List<ExpoPushMessage> messages = new ArrayList<>();
-        messages.add(new ExpoPushMessage(Collections.nCopies(messagesLength, "?")));
-        List<List<ExpoPushMessage>> chunks = client.chunkPushNotifications(messages);
+        DefaultPushClient client = new DefaultPushClient();
+        List<DefaultExpoPushMessage> messages = new ArrayList<>();
+        messages.add(new DefaultExpoPushMessage(Collections.nCopies(messagesLength, "?")));
+        List<List<DefaultExpoPushMessage>> chunks = client.chunkPushNotifications(messages);
         assertEquals(1, chunks.size());
         assertEquals(1, chunks.get(0).size());
         assertEquals(messagesLength, chunks.get(0).get(0).to.size());
@@ -80,14 +99,14 @@ class PushClientTest {
 
     @Test
     public void chunksPushNotificationMessagesMixedWithListsOfRecipientsAndSingleRecipient() {
-        PushClient client = new PushClient();
-        List<ExpoPushMessage> messages = new ArrayList<>();
-        messages.add(new ExpoPushMessage(Collections.nCopies(888, "?")));
-        messages.addAll(Collections.nCopies(999, new ExpoPushMessage("?")));
-        messages.add(new ExpoPushMessage(Collections.nCopies(90, "?")));
-        messages.addAll(Collections.nCopies(10, new ExpoPushMessage("?")));
+        DefaultPushClient client = new DefaultPushClient();
+        List<DefaultExpoPushMessage> messages = new ArrayList<>();
+        messages.add(new DefaultExpoPushMessage(Collections.nCopies(888, "?")));
+        messages.addAll(Collections.nCopies(999, new DefaultExpoPushMessage("?")));
+        messages.add(new DefaultExpoPushMessage(Collections.nCopies(90, "?")));
+        messages.addAll(Collections.nCopies(10, new DefaultExpoPushMessage("?")));
 
-        List<List<ExpoPushMessage>> chunks = client.chunkPushNotifications(messages);
+        List<List<DefaultExpoPushMessage>> chunks = client.chunkPushNotifications(messages);
         long totalMessageCount = _countAndValidateMessages(chunks);
         assertEquals(888 + 999 + 90 + 10, totalMessageCount);
     }
@@ -95,7 +114,7 @@ class PushClientTest {
     @Test
     public void isExponentPushTokenCanValidateTokens() {
         String validToken1 = "ExpoPushToken[xxxxxxxxxxxxxxxxxxxxxx]";
-        assertEquals(true, PushClient.isExponentPushToken(validToken1), "Test that \"ExpoPusToken[\" is a valid token");
+        assertEquals(true, PushClient.isExponentPushToken(validToken1), "Test that \"ExpoPushToken[\" is a valid token");
         String validToken2 = "ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]";
         assertEquals(true, PushClient.isExponentPushToken(validToken2), "Test that \"ExponentPushToken[\" is a valid token");
         String validToken3 = "F5741A13-BCDA-434B-A316-5DC0E6FFA94F";
@@ -104,14 +123,14 @@ class PushClientTest {
         String inValidToken1 = "ExponentPushToken xxxxxxxxxxxxxxxxxxxxxx";
         assertEquals(false, PushClient.isExponentPushToken(inValidToken1), "Stripped []");
         String inValidToken2 = "ExpoXXXXXushToken[xxxxxxxxxxxxxxxxxxxxxx]";
-        assertEquals(false, PushClient.isExponentPushToken(inValidToken1), "Mangeled prefix");
+        assertEquals(false, PushClient.isExponentPushToken(inValidToken2), "Mangeled prefix");
         String inValidToken3 = "ExponentPushToken[]";
-        assertEquals(false, PushClient.isExponentPushToken(inValidToken1), "Empty key field");
+        assertEquals(false, PushClient.isExponentPushToken(inValidToken3), "Empty key field");
     }
 
     @Test
     public void chunkPushNotificationReceiptIdsCanChunkCorrectly() {
-        PushClient client = new PushClient();
+        DefaultPushClient client = new DefaultPushClient();
         List<String> recieptIds = new ArrayList<>(Collections.nCopies(60, "F5741A13-BCDA-434B-A316-5DC0E6FFA94F"));
         List<List<String>> chunks = client.chunkPushNotificationReceiptIds(recieptIds);
         int totalReceiptIdCount = 0;
@@ -123,11 +142,11 @@ class PushClientTest {
 
     @Test
     public void chunkTwoMessagesAndOneAdditionalMessageWithNoRecipient() {
-        PushClient client = new PushClient();
+        DefaultPushClient client = new DefaultPushClient();
 
-        List<ExpoPushMessage> messages = new ArrayList<>(Collections.nCopies(2, new ExpoPushMessage("?")));
-        messages.add(new ExpoPushMessage(new ArrayList<>()));
-        List<List<ExpoPushMessage>> chunks = client.chunkPushNotifications(messages);
+        List<DefaultExpoPushMessage> messages = new ArrayList<>(Collections.nCopies(2, new DefaultExpoPushMessage("?")));
+        messages.add(new DefaultExpoPushMessage(new ArrayList<>()));
+        List<List<DefaultExpoPushMessage>> chunks = client.chunkPushNotifications(messages);
         assertEquals(1, chunks.size());
         long totalMessageCount = _countAndValidateMessages(chunks);
         assertEquals(2, totalMessageCount);
@@ -135,10 +154,10 @@ class PushClientTest {
 
     @Test
     public void chunkOneMessageWith100Recipients() {
-        PushClient client = new PushClient();
-        List<ExpoPushMessage> messages = new ArrayList<>();
-        messages.add(new ExpoPushMessage(Collections.nCopies(100, "?")));
-        List<List<ExpoPushMessage>> chunks = client.chunkPushNotifications(messages);
+        DefaultPushClient client = new DefaultPushClient();
+        List<DefaultExpoPushMessage> messages = new ArrayList<>();
+        messages.add(new DefaultExpoPushMessage(Collections.nCopies(100, "?")));
+        List<List<DefaultExpoPushMessage>> chunks = client.chunkPushNotifications(messages);
         assertEquals(1, chunks.size());
         assertEquals(1, chunks.get(0).size());
         assertEquals(100, chunks.get(0).get(0).to.size());
@@ -147,10 +166,10 @@ class PushClientTest {
     @Test
     // TODO: This test only works because we assume that max-chunk size is 100
     public void chunkOneMessageWith101Recipients() {
-        PushClient client = new PushClient();
-        List<ExpoPushMessage> messages = new ArrayList<>();
-        messages.add(new ExpoPushMessage(Collections.nCopies(101, "?")));
-        List<List<ExpoPushMessage>> chunks = client.chunkPushNotifications(messages);
+        DefaultPushClient client = new DefaultPushClient();
+        List<DefaultExpoPushMessage> messages = new ArrayList<>();
+        messages.add(new DefaultExpoPushMessage(Collections.nCopies(101, "?")));
+        List<List<DefaultExpoPushMessage>> chunks = client.chunkPushNotifications(messages);
         assertEquals(2, chunks.size());
         assertEquals(1, chunks.get(0).size());
         assertEquals(1, chunks.get(1).size());
@@ -161,13 +180,13 @@ class PushClientTest {
     @Test
     // TODO: This test only works because we assume that max-chunk size is 100
     public void chunkOneMessageWith99RecipientsAndTwoAdditionalMessages() {
-        PushClient client = new PushClient();
-        List<ExpoPushMessage> messages = new ArrayList<>();
-        messages.add(new ExpoPushMessage(Collections.nCopies(99, "?")));
-        messages.add(new ExpoPushMessage("?"));
-        messages.add(new ExpoPushMessage("?"));
+        DefaultPushClient client = new DefaultPushClient();
+        List<DefaultExpoPushMessage> messages = new ArrayList<>();
+        messages.add(new DefaultExpoPushMessage(Collections.nCopies(99, "?")));
+        messages.add(new DefaultExpoPushMessage("?"));
+        messages.add(new DefaultExpoPushMessage("?"));
 
-        List<List<ExpoPushMessage>> chunks = client.chunkPushNotifications(messages);
+        List<List<DefaultExpoPushMessage>> chunks = client.chunkPushNotifications(messages);
         assertEquals(2, chunks.size());
         assertEquals(2, chunks.get(0).size());
         assertEquals(1, chunks.get(1).size());
@@ -178,13 +197,13 @@ class PushClientTest {
     @Test
     // TODO: This test only works because we assume that max-chunk size is 100
     public void chunkOneMessageWith100RecipientsAndTwoAdditionalMessages() {
-        PushClient client = new PushClient();
-        List<ExpoPushMessage> messages = new ArrayList<>();
-        messages.add(new ExpoPushMessage(Collections.nCopies(100, "?")));
-        messages.add(new ExpoPushMessage("?"));
-        messages.add(new ExpoPushMessage("?"));
+        DefaultPushClient client = new DefaultPushClient();
+        List<DefaultExpoPushMessage> messages = new ArrayList<>();
+        messages.add(new DefaultExpoPushMessage(Collections.nCopies(100, "?")));
+        messages.add(new DefaultExpoPushMessage("?"));
+        messages.add(new DefaultExpoPushMessage("?"));
 
-        List<List<ExpoPushMessage>> chunks = client.chunkPushNotifications(messages);
+        List<List<DefaultExpoPushMessage>> chunks = client.chunkPushNotifications(messages);
         assertEquals(2, chunks.size());
         assertEquals(1, chunks.get(0).size());
         assertEquals(2, chunks.get(1).size());
@@ -196,11 +215,11 @@ class PushClientTest {
     @Test
     // TODO: This test only works because we assume that max-chunk size is 100
     public void chunk99MessagesAndOneAdditionalMessageWithTwoRecipients() {
-        PushClient client = new PushClient();
-        List<ExpoPushMessage> messages = new ArrayList<>((Collections.nCopies(99, new ExpoPushMessage("?"))));
-        messages.add(new ExpoPushMessage(Collections.nCopies(2, "?")));
+        DefaultPushClient client = new DefaultPushClient();
+        List<DefaultExpoPushMessage> messages = new ArrayList<>((Collections.nCopies(99, new DefaultExpoPushMessage("?"))));
+        messages.add(new DefaultExpoPushMessage(Collections.nCopies(2, "?")));
 
-        List<List<ExpoPushMessage>> chunks = client.chunkPushNotifications(messages);
+        List<List<DefaultExpoPushMessage>> chunks = client.chunkPushNotifications(messages);
         assertEquals(2, chunks.size());
         assertEquals(100, chunks.get(0).size());
         assertEquals(1, chunks.get(1).size());
@@ -210,25 +229,25 @@ class PushClientTest {
 
     @Test
     public void chunkNoMessage() {
-        PushClient client = new PushClient();
-        List<ExpoPushMessage> messages = new ArrayList<>();
-        List<List<ExpoPushMessage>> chunks = client.chunkPushNotifications(messages);
+        DefaultPushClient client = new DefaultPushClient();
+        List<DefaultExpoPushMessage> messages = new ArrayList<>();
+        List<List<DefaultExpoPushMessage>> chunks = client.chunkPushNotifications(messages);
         assertEquals(0, chunks.size());
     }
 
     @Test
     public void chunkSingleMessageWithNoRecipient() {
-        PushClient client = new PushClient();
-        List<ExpoPushMessage> messages = new ArrayList();
-        messages.add(new ExpoPushMessage());
-        List<List<ExpoPushMessage>> chunks = client.chunkPushNotifications(messages);
+        DefaultPushClient client = new DefaultPushClient();
+        List<DefaultExpoPushMessage> messages = new ArrayList();
+        messages.add(new DefaultExpoPushMessage());
+        List<List<DefaultExpoPushMessage>> chunks = client.chunkPushNotifications(messages);
         assertEquals(0, chunks.size());
     }
 
-    private long _countAndValidateMessages(List<List<ExpoPushMessage>> chunks) {
+    private long _countAndValidateMessages(List<List<DefaultExpoPushMessage>> chunks) {
         long totalMessageCount = 0;
-        for (List<ExpoPushMessage> chunk : chunks) {
-            long chunkMessagesCount = PushClient._getActualMessagesCount(chunk);
+        for (List<DefaultExpoPushMessage> chunk : chunks) {
+            long chunkMessagesCount = DefaultPushClient._getActualMessagesCount(chunk);
             assert (chunkMessagesCount <= PushClient.PUSH_NOTIFICATION_CHUNK_LIMIT);
             totalMessageCount += chunkMessagesCount;
         }


### PR DESCRIPTION
Fixes #12 
Fixes #14 
Fixes #15 

This was deliberately not backwards compatible as I do not believe the 0.7 implementation is as useful as this POJO version and the version is still in the 0.X. This is debatable of course, let me know what you want to do.  I have not updated the README  but can make the change after naming conventions are agreed upon.

DefaultPushClient and DefaultExpoPushMessage are equivalent to the 0.7 versions and pass all test cases. 

The POM was set up for local deployment so I could test in production without a snapshot version. This should not be merged.
 
Current usage is:
```
    PushClient<ExpoPushMessage<MyNotification>> pushClient;
    ExpoPushMessage<MyNotification> epm = new ExpoPushMessage<>(recepient, MyNotification.class);
    epm.title = "Title";
    epm.data = new MyNotification();
    messages.add(epm);
    List<List<ExpoPushMessage<MyNotification>>> chunks = pushClient.chunkPushNotifications(messages);
```
Id prefer it to be `PushClient<MyNotification>...` but I got hung up on the generics a bit so went with the simpler version for now
