### PR TITLE
Corrected "ExpoPushReceipt" ->"ExpoPushReceiept"

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ package io.github.jav.exposerversdk.examples;
 
 import io.github.jav.exposerversdk.ExpoPushMessage;
 import io.github.jav.exposerversdk.ExpoPushMessageTicketPair;
-import io.github.jav.exposerversdk.ExpoPushReceipt;
+import io.github.jav.exposerversdk.ExpoPushReceiept;
 import io.github.jav.exposerversdk.ExpoPushTicket;
 import io.github.jav.exposerversdk.PushClient;
 import io.github.jav.exposerversdk.PushClientException;
@@ -98,9 +98,9 @@ public class ExampleExpoServer {
         System.out.println("Fetching reciepts...");
 
         List<String> ticketIds = (client.getTicketIdsFromPairs(okTicketMessages));
-        CompletableFuture<List<ExpoPushReceipt>> receiptFutures = client.getPushNotificationReceiptsAsync(ticketIds);
+        CompletableFuture<List<ExpoPushReceiept>> receiptFutures = client.getPushNotificationReceiptsAsync(ticketIds);
 
-        List<ExpoPushReceipt> receipts = new ArrayList<>();
+        List<ExpoPushReceiept> receipts = new ArrayList<>();
         try {
             receipts = receiptFutures.get();
         } catch (ExecutionException e) {
@@ -112,7 +112,7 @@ public class ExampleExpoServer {
         System.out.println(
                 "Recieved " + receipts.size() + " receipts:");
 
-        for (ExpoPushReceipt reciept : receipts) {
+        for (ExpoPushReceiept reciept : receipts) {
             System.out.println(
                     "Receipt for id: " +
                             reciept.getId() +


### PR DESCRIPTION
Although you have used the correct spelling (ExpoPushReceipt), it appears that the code actually points to "ExpoPushReceiept", which is a typo in itself.