### PR TITLE
updated jackson dependencies to 2.12.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-f![Java CI with Maven](https://github.com/jav/expo-server-sdk-java/workflows/Java%20CI%20with%20Maven/badge.svg)
+![Java CI with Maven](https://github.com/jav/expo-server-sdk-java/workflows/Java%20CI%20with%20Maven/badge.svg)
 
 ## expo-server-sdk-java
 This is a java implementation of the [node server-side library](https://github.com/expo/expo-server-sdk-node) for working with expo using Java.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-f![Java CI with Maven](https://github.com/jav/expo-server-sdk-java/workflows/Java%20CI%20with%20Maven/badge.svg)
+![Java CI with Maven](https://github.com/jav/expo-server-sdk-java/workflows/Java%20CI%20with%20Maven/badge.svg)
 
 ## expo-server-sdk-java
 This is a java implementation of the [node server-side library](https://github.com/expo/expo-server-sdk-node) for working with expo using Java.
@@ -14,7 +14,7 @@ package io.github.jav.exposerversdk.examples;
 
 import io.github.jav.exposerversdk.ExpoPushMessage;
 import io.github.jav.exposerversdk.ExpoPushMessageTicketPair;
-import io.github.jav.exposerversdk.ExpoPushReceiept;
+import io.github.jav.exposerversdk.ExpoPushReceipt;
 import io.github.jav.exposerversdk.ExpoPushTicket;
 import io.github.jav.exposerversdk.PushClient;
 import io.github.jav.exposerversdk.PushClientException;
@@ -98,9 +98,9 @@ public class ExampleExpoServer {
         System.out.println("Fetching reciepts...");
 
         List<String> ticketIds = (client.getTicketIdsFromPairs(okTicketMessages));
-        CompletableFuture<List<ExpoPushReceiept>> receiptFutures = client.getPushNotificationReceiptsAsync(ticketIds);
+        CompletableFuture<List<ExpoPushReceipt>> receiptFutures = client.getPushNotificationReceiptsAsync(ticketIds);
 
-        List<ExpoPushReceiept> receipts = new ArrayList<>();
+        List<ExpoPushReceipt> receipts = new ArrayList<>();
         try {
             receipts = receiptFutures.get();
         } catch (ExecutionException e) {
@@ -112,7 +112,7 @@ public class ExampleExpoServer {
         System.out.println(
                 "Recieved " + receipts.size() + " receipts:");
 
-        for (ExpoPushReceiept reciept : receipts) {
+        for (ExpoPushReceipt reciept : receipts) {
             System.out.println(
                     "Receipt for id: " +
                             reciept.getId() +

--- a/pom.xml
+++ b/pom.xml
@@ -111,12 +111,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>[2.9.10.5,)</version>
+            <version>2.12.3</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.10.2</version>
+            <version>2.12.3</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
Updates `com.fasterxml.jackson.core` dependencies to more recent version which accomplishes two things:

1. Makes this sdk compatible with SpringBoot version 2.5 (current known compatibility ends at 2.4.5) which uses `com.fasterxml.jackson.core` dependencies at 2.12.3 (see https://docs.spring.io/spring-boot/docs/2.5.0/reference/html/dependency-versions.html#dependency-versions). Prior to this update to the dependencies SpringBoot 2.5 will break when combined with this SDK and certain SpringBoot functionality usages. See example below:
```
org.springframework.web.util.NestedServletException: Handler dispatch failed; nested exception is java.lang.NoSuchMethodError: 'boolean com.fasterxml.jackson.databind.SerializationConfig.hasExplicitTimeZone()'
```

2. Fixes a failing `maven clean package`